### PR TITLE
Extension of COESA model to 86km - 2nd try

### DIFF
--- a/skaero/atmosphere/coesa.py
+++ b/skaero/atmosphere/coesa.py
@@ -24,9 +24,7 @@ Notes
 Based on the U.S. 1976 Standard Atmosphere.
 
 .. _`U.S. 1976 Standard Atmosphere`: http://ntrs.nasa.gov/search.jsp?R=19770009\
-539&hterms=standard+atmosphere&qs=N%3D0%26Ntk%3DAll%26Ntt%3Dstandard%2520atmosp\
-here%26Ntx%3Dmode%2520matchallpartial%26Nm%3D123%7CCollection%7CNASA%2520STI%7C\
-%7C17%7CCollection%7CNACA
+539
 
 """
 
@@ -48,10 +46,10 @@ Rs = 8.31432  # N m / (mol K), WARNING : different from the the 2010 CODATA
 # Recommended Values of the Fundamental Physical Constants
 
 # set of geopotential heights from table 2 of Notes reference
-H = np.array([0., 11.0, 20.0, 32., 47., 51., 71.00, 84.85205])*10**3  # m
+H = np.array([0., 11.0, 20.0, 32., 47., 51., 71.00, 84.85205])*1e3  # m
 
 # set of molecular-scale temperature gradients from table 2 of Notes reference
-LM = np.array([-6.5, 0., 1., 2.8, 0., -2.8, -2., 0.])*10**(-3)  # K / m
+LM = np.array([-6.5, 0., 1., 2.8, 0., -2.8, -2., 0.])*1e-3  # K / m
 
 f_LM = interpolate.interp1d(H, LM, kind='zero')
 
@@ -59,7 +57,7 @@ f_LM = interpolate.interp1d(H, LM, kind='zero')
 T_0 = 288.15  # K
 
 # mean molecular-weight at sea-level
-M_0 = 28.9644*10**(-3)  # kg / mol
+M_0 = 28.9644e-3  # kg / mol
 
 # set of geopotential heights from table 8 of Notes reference 
 H2 = np.array([0., 79005.7, 79493.3, 79980.8, 80468.2, 80955.7, 81443.0,
@@ -105,7 +103,7 @@ def table(x, kind='geopotential'):
     x : array_like
        Geopotential or geometric altitude (depending on kind) given in meters.
     kind : str
-       Specifies the kind of interpolation as altitude x ('geopotential' or \
+       Specifies the kind of interpolation as altitude x ('geopotential' or 
 'geometric'). Default is 'geopotential'
 
     Returns
@@ -124,9 +122,7 @@ def table(x, kind='geopotential'):
     Based on the U.S. 1976 Standard Atmosphere.
 
     .. _`U.S. 1976 Standard Atmosphere`: http://ntrs.nasa.gov/search.jsp?R=1977\
-0009539&hterms=standard+atmosphere&qs=N%3D0%26Ntk%3DAll%26Ntt%3Dstandard%25\
-20atmosphere%26Ntx%3Dmode%2520matchallpartial%26Nm%3D123%7CCollection%7CNAS\
-A%2520STI%7C%7C17%7CCollection%7CNACA
+0009539
 
     """
     
@@ -184,7 +180,7 @@ A%2520STI%7C%7C17%7CCollection%7CNACA
 
 
 def temperature(x, kind='geopotential'):
-    """Computes air temperature for a given altitude using the U.S. standard \
+    """Computes air temperature for a given altitude using the U.S. standard 
 atmosphere model
 
     Parameters
@@ -192,7 +188,7 @@ atmosphere model
     x : array_like
        Geopotential or geometric altitude (depending on kind) given in meters.
     kind : str
-       Specifies the kind of interpolation as altitude x ('geopotential' or \
+       Specifies the kind of interpolation as altitude x ('geopotential' or 
 'geometric'). Default is 'geopotential'
 
     Returns
@@ -205,9 +201,7 @@ atmosphere model
     Based on the U.S. 1976 Standard Atmosphere.
 
     .. _`U.S. 1976 Standard Atmosphere`: http://ntrs.nasa.gov/search.jsp?R=1977\
-0009539&hterms=standard+atmosphere&qs=N%3D0%26Ntk%3DAll%26Ntt%3Dstandard%25\
-20atmosphere%26Ntx%3Dmode%2520matchallpartial%26Nm%3D123%7CCollection%7CNAS\
-A%2520STI%7C%7C17%7CCollection%7CNACA
+0009539
 
     """
     
@@ -216,7 +210,7 @@ A%2520STI%7C%7C17%7CCollection%7CNACA
 
 
 def pressure(x, kind='geopotential'):
-    """Computes absolute pressure for a given altitude using the U.S. standard \
+    """Computes absolute pressure for a given altitude using the U.S. standard 
 atmosphere model
 
     Parameters
@@ -224,7 +218,7 @@ atmosphere model
     x : array_like
        Geopotential or geometric altitude (depending on kind) given in meters.
     kind : str
-       Specifies the kind of interpolation as altitude x ('geopotential' or \
+       Specifies the kind of interpolation as altitude x ('geopotential' or 
 'geometric'). Default is 'geopotential'
 
     Returns
@@ -237,9 +231,7 @@ atmosphere model
     Based on the U.S. 1976 Standard Atmosphere.
 
     .. _`U.S. 1976 Standard Atmosphere`: http://ntrs.nasa.gov/search.jsp?R=1977\
-0009539&hterms=standard+atmosphere&qs=N%3D0%26Ntk%3DAll%26Ntt%3Dstandard%25\
-20atmosphere%26Ntx%3Dmode%2520matchallpartial%26Nm%3D123%7CCollection%7CNAS\
-A%2520STI%7C%7C17%7CCollection%7CNACA
+0009539
 
     """
     
@@ -248,7 +240,7 @@ A%2520STI%7C%7C17%7CCollection%7CNACA
 
 
 def density(x, kind='geopotential'):
-    """Computes air mass density for a given altitude using the U.S. standard \
+    """Computes air mass density for a given altitude using the U.S. standard 
 atmosphere model
 
     Parameters
@@ -256,7 +248,7 @@ atmosphere model
     x : array_like
        Geopotential or geometric altitude (depending on kind) given in meters.
     kind : str
-       Specifies the kind of interpolation as altitude x ('geopotential' or \
+       Specifies the kind of interpolation as altitude x ('geopotential' or 
 'geometric'). Default is 'geopotential'
 
     Returns
@@ -269,9 +261,7 @@ atmosphere model
     Based on the U.S. 1976 Standard Atmosphere.
 
     .. _`U.S. 1976 Standard Atmosphere`: http://ntrs.nasa.gov/search.jsp?R=1977\
-0009539&hterms=standard+atmosphere&qs=N%3D0%26Ntk%3DAll%26Ntt%3Dstandard%25\
-20atmosphere%26Ntx%3Dmode%2520matchallpartial%26Nm%3D123%7CCollection%7CNAS\
-A%2520STI%7C%7C17%7CCollection%7CNACA
+0009539
 
     """
 

--- a/skaero/atmosphere/util.py
+++ b/skaero/atmosphere/util.py
@@ -10,7 +10,7 @@ from __future__ import division, absolute_import
 import numpy as np
 
 # effective earth's radius
-R_Earth = 6356.7660*10**3  # m
+R_Earth = 6356.7660e3  # m
 
 def geometric_to_geopotential(z):
     """Returns geopotential altitude from geometric altitude.
@@ -50,9 +50,7 @@ def geopotential_to_geometric(h):
     Based on eq. 19 of the U.S. 1976 Standard Atmosphere.
 
     .. _`U.S. 1976 Standard Atmosphere`: http://ntrs.nasa.gov/search.jsp?R=1977\
-0009539&hterms=standard+atmosphere&qs=N%3D0%26Ntk%3DAll%26Ntt%3Dstandard%25\
-20atmosphere%26Ntx%3Dmode%2520matchallpartial%26Nm%3D123%7CCollection%7CNAS\
-A%2520STI%7C%7C17%7CCollection%7CNACA
+0009539
 
     """
 

--- a/tests/test_coesa.py
+++ b/tests/test_coesa.py
@@ -1,120 +1,157 @@
 # coding: utf-8
 
 """
-Tests of the U.S. 1976 Standard Atmosphere implementation.
+Tests of the U.S. 1976 Standard Atmosphere implementation. All of them are
+validated against the `standard`_.
 
-Most of the tests here are validated against the data tables provided
-in the `PDAS Standard Atmosphere`_, which are included here. Only
-test_under_1000 uses the values of the `standard`_, and it is retained just
-for historical reasons because there seems to be some inaccuracies there.
-
-Data generated using tables.py from PDAS.
-
-.. _`PDAS Standard Atmosphere`: http://www.pdas.com/atmos.html
 .. _`standard`: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770009539_1977009539.pdf
-
-TODO
-----
-* Too much repeated code: refactor.
 
 """
 
 from __future__ import division, absolute_import
 
 import numpy as np
+from numpy.testing import (assert_equal, assert_almost_equal,
+                           assert_array_equal, assert_array_almost_equal)
 import scipy as sp
-import numpy.testing
 import scipy.constants
 
-from skaero.atmosphere import coesa
-
-
-# Load data from PDAS atmos
-data = np.loadtxt('tests/si2py.prt', skiprows=2)
+from skaero.atmosphere import coesa, util
 
 
 def test_sea_level():
     """Tests sea level values.
 
     """
-    h, T, p, rho = coesa.table(0.0)
+    h = 0.0
+    expected_h = 0.0
+    expected_T = sp.constants.C2K(15)
+    expected_p = sp.constants.atm
+    expected_rho = 1.2250
 
-    np.testing.assert_equal(h, 0.0)
-    np.testing.assert_equal(T, sp.constants.C2K(15))
-    np.testing.assert_equal(p, sp.constants.atm)
-    np.testing.assert_almost_equal(rho, 1.2250, decimal=3)
+    h, T, p, rho = coesa.table(h)
+
+    assert_equal(h, expected_h)
+    assert_equal(T, expected_T)
+    assert_equal(p, expected_p)
+    assert_almost_equal(rho, expected_rho, decimal=4)
 
 
 def test_sea_level_0d_array():
     """Tests sea level values using zero dimension array.
 
     """
-    h_ = np.array(0.0)
-    T_ = np.array(sp.constants.C2K(15))
-    p_ = np.array(sp.constants.atm)
-    rho_ = np.array(1.2250)
+    h = np.array(0.0)
+    expected_h = np.array(0.0)
+    expected_T = np.array(sp.constants.C2K(15))
+    expected_p = np.array(sp.constants.atm)
+    expected_rho = np.array(1.2250)
 
-    h, T, p, rho = coesa.table(h_)
+    h, T, p, rho = coesa.table(h)
 
-    np.testing.assert_array_equal(h, h_)
-    np.testing.assert_array_almost_equal(T, T_, decimal=3)
-    np.testing.assert_array_almost_equal(p, p_, decimal=3)
-    np.testing.assert_array_almost_equal(rho, rho_, decimal=3)
+    assert_array_equal(h, expected_h)
+    assert_array_almost_equal(T, expected_T)
+    assert_array_almost_equal(p, expected_p)
+    assert_array_almost_equal(rho, expected_rho)
 
 
 def test_sea_level_nd_array():
     """Tests sea level values using n dimension array.
 
     """
-    h_ = np.array([0.0, 0.0, 0.0])
-    h, T, p, rho = coesa.table(h_)
+    h = np.array([0.0, 0.0, 0.0])
+    expected_h = np.array([0.0, 0.0, 0.0])
+    expected_T = np.array([288.15] * 3)
+    expected_p = np.array([101325.0] * 3)
+    expected_rho = np.array([1.2250] * 3)
 
-    np.testing.assert_array_equal(h, h_)
-    np.testing.assert_array_almost_equal(
-        T, [288.15] * 3, decimal=3)
-    np.testing.assert_array_almost_equal(
-        p, [101325.0] * 3, decimal=3)
-    np.testing.assert_array_almost_equal(
-        rho, [1.2250] * 3, decimal=3)
+    h, T, p, rho = coesa.table(h)
+
+    assert_array_equal(h, expected_h)
+    assert_array_almost_equal(T, expected_T)
+    assert_array_almost_equal(p, expected_p)
+    assert_array_almost_equal(rho, expected_rho)
+
+
+def test_geometric_to_geopotential():
+    z = np.array([50.0, 5550.0, 10450.0])
+    h = util.geometric_to_geopotential(z)
+    expected_h = np.array([50.0, 5545.0, 10433.0])
+    assert_array_almost_equal(h, expected_h, decimal=0)
 
 
 def test_under_1000m():
     """Tests for altitude values under 1000.0 m
 
     """
-    z_ = np.array([50.0, 550.0, 850.0])
-    h_ = coesa.geometric_to_geopotential(z_)
+    z = np.array([50.0, 550.0, 850.0])
+    h = util.geometric_to_geopotential(z)
+    expected_h = np.array([50.0, 550.0, 850.0])
+    expected_T = np.array([287.825, 284.575, 282.626])
+    expected_p = np.array([100720.0, 94890.0, 91523.0])
+    expected_rho = np.array([1.2191, 1.1616, 1.1281])
 
-    # Retrieve desired data from PDAS tables
-    desired = np.array([data[data[:, 0] == x][0] for x in z_])
+    h, T, p, rho = coesa.table(h)
 
-    T_ = desired[:, 4]
-    p_ = desired[:, 5]
-    rho_ = desired[:, 6]
-
-    h, T, p, rho = coesa.table(h_)
-
-    np.testing.assert_array_almost_equal(T, T_, decimal=1)
-    np.testing.assert_array_almost_equal(p, p_, decimal=0)
-    np.testing.assert_array_almost_equal(rho, rho_, decimal=3)
+    assert_array_almost_equal(h, expected_h, decimal=0)
+    assert_array_almost_equal(T, expected_T, decimal=3)
+    assert_array_almost_equal(p, expected_p, decimal=-1)
+    assert_array_almost_equal(rho, expected_rho, decimal=4)
 
 
 def test_under_11km():
-    """Tests for altitude values under 11 km (first layer)
+    """Tests for altitude values between 1 and 11 km
 
     """
-    z_ = np.array([500.0, 2500.0, 6500.0, 9000.0, 11000.0])
-    h_ = coesa.geometric_to_geopotential(z_)
+    z = np.array([500.0, 2500.0, 6500.0, 9000.0, 11000.0])
+    h = util.geometric_to_geopotential(z)
+    expected_h = np.array([500.0, 2499.0, 6493.0, 8987.0, 10981.0])
+    expected_T = np.array([284.900, 271.906, 245.943, 229.733, 216.774])
+    expected_p = np.array([95461.0, 74691.0, 44075.0, 30800.0, 22699.0])
+    expected_rho = np.array([1.1673, 0.95695, 0.62431, 0.46706, 0.36480])
 
-    # Retrieve desired data from PDAS tables
-    desired = np.array([data[data[:, 0] == x][0] for x in z_])
+    h, T, p, rho = coesa.table(h)
+    
+    assert_array_almost_equal(h, expected_h, decimal=0)
+    assert_array_almost_equal(T, expected_T, decimal=3)
+    assert_array_almost_equal(p, expected_p, decimal=0)
+    assert_array_almost_equal(rho, expected_rho, decimal=4)
 
-    T_ = desired[:, 4]
-    p_ = desired[:, 5]
-    rho_ = desired[:, 6]
 
-    h, T, p, rho = coesa.table(h_)
+def test_under_35km():
+    """Tests for altitude values between 11 and 35 km
 
-    np.testing.assert_array_almost_equal(T, T_, decimal=1)
-    np.testing.assert_array_almost_equal(p, p_, decimal=0)
-    np.testing.assert_array_almost_equal(rho, rho_, decimal=3)
+    """
+    z = np.array([15000.0, 25000.0, 35000.0])
+    h = util.geometric_to_geopotential(z)
+    expected_h = np.array([14965.0, 24902., 34808.0])
+    expected_T = np.array([216.65, 221.552, 236.513])
+    expected_p = np.array([12111.0, 2549.2, 574.59])
+    expected_rho = np.array([0.19476, 0.040084, 0.0084634])
+
+    h, T, p, rho = coesa.table(h)
+    
+    assert_array_almost_equal(h, expected_h, decimal=0)
+    assert_array_almost_equal(T, expected_T, decimal=3)
+    assert_array_almost_equal(p, expected_p, decimal=0)
+    assert_array_almost_equal(rho, expected_rho, decimal=5)
+
+
+def test_under_86km():
+    """Tests for altitude values between 35 and 86 km
+
+    """
+    z = np.array([50000.0, 70000.0, 86000.0])
+    h = util.geometric_to_geopotential(z)
+    expected_h = np.array([49610.0, 69238., 84852.0])
+    expected_T = np.array([270.65, 219.585, 186.87])
+    expected_p = np.array([79.779, 5.2209, 0.37338])
+    expected_rho = np.array([0.0010269, 0.000082829, 0.000006958])
+
+    h, T, p, rho = coesa.table(h)
+    
+    assert_array_almost_equal(h, expected_h, decimal=0)
+    assert_array_almost_equal(T, expected_T, decimal=2)
+    assert_array_almost_equal(p, expected_p, decimal=3)
+    assert_array_almost_equal(rho, expected_rho, decimal=7)
+


### PR DESCRIPTION
Hello  Juan,

Here is a new pull request for the extension of the COESA model. 

I got rid of the unnecessary `np.array()` by changing them for `np.asarray()` which is indeed much faster.
I used `np.exp` rather than `scipy.exp` thus avoiding an import.
I PEP8-cleaned `coesa.py` even though it is not perfect yet.
I did not create a constant module since most of the constants are either very specific to coesa or already available in the `scipy.constants` module. It's up to you if you want to create such a module, maybe it can be useful when this scikit grows.

I think this is better now. Please, do not hesitate if you have further remarks.

Finally, I followed the steps you kindly suggested to me regarding git. Everything went all right as you can see. Thank you.

Regards.

Gilles
