### PR TITLE
Add speed of sound isentropic ratio

### DIFF
--- a/skaero/gasdynamics/isentropic.py
+++ b/skaero/gasdynamics/isentropic.py
@@ -232,6 +232,24 @@ class IsentropicFlow(object):
             )
         return A_Astar
 
+    def a_a0(self, M):
+        """ Speed of sound ratio from Mach number.
+
+        Parameters
+        ----------
+        M: array_like
+            Mach number.
+
+        Returns
+        -------
+        a_a0: array_like
+            Speed of sound ratio.
+        """
+
+        M = np.asarray(M)
+        a_a0 = self.T_T0(M) ** 0.5
+
+        return a_a0
 
 class PrandtlMeyerExpansion(object):
     """Class representing a Prandtl-Meyer expansion fan.

--- a/tests/test_isentropic.py
+++ b/tests/test_isentropic.py
@@ -141,6 +141,15 @@ def test_mach_from_area_ratio_raises_error_when_ratio_is_subsonic():
     with pytest.raises(ValueError):
         isentropic.mach_from_area_ratio(0.9)
 
+def test_speed_of_sound_ratio():
+    fl = isentropic.IsentropicFlow(1.4)
+    M_list = [0.0, 0.3, 1.0, 1.3, 2.5]
+    expected_sound_speed_ratios = [1.0, 0.99112, 0.91287, 0.86451, 0.6667]
+
+    np.testing.assert_array_almost_equal(
+        fl.a_a0(M_list), expected_sound_speed_ratios, decimal=3
+    )
+
 
 def test_mach_from_area_ratio_subsonic():
     fl = isentropic.IsentropicFlow(1.4)


### PR DESCRIPTION
As requested in #10, speed of sound is added to gas dynamics and also a test :rocket: 