### PR TITLE
improved initial condition for supersonic calculation. Changed A*=inf…

### DIFF
--- a/skaero/gasdynamics/isentropic.py
+++ b/skaero/gasdynamics/isentropic.py
@@ -66,14 +66,18 @@ def mach_from_area_ratio(A_Astar, fl=None):
     """
     if not fl:
         fl = IsentropicFlow(gamma=1.4)
+
     eq = implicit(fl.A_Astar)
+
     if A_Astar < 1.0:
         raise ValueError("Area ratio must be greater than 1")
     elif A_Astar == 1.0:
         M_sub = M_sup = 1.0
     else:
         M_sub = sp.optimize.bisect(eq, 0.0, 1.0, args=(A_Astar,))
-        M_sup = sp.optimize.newton(eq, 2.0, args=(A_Astar,))
+
+        ic = 100 * np.log(A_Astar) + 1  # improved initial condition
+        M_sup = sp.optimize.newton(eq, ic, args=(A_Astar,))
 
     return M_sub, M_sup
 

--- a/tests/test_isentropic.py
+++ b/tests/test_isentropic.py
@@ -141,6 +141,7 @@ def test_mach_from_area_ratio_raises_error_when_ratio_is_subsonic():
     with pytest.raises(ValueError):
         isentropic.mach_from_area_ratio(0.9)
 
+
 def test_speed_of_sound_ratio():
     fl = isentropic.IsentropicFlow(1.4)
     M_list = [0.0, 0.3, 1.0, 1.3, 2.5]
@@ -153,51 +154,27 @@ def test_speed_of_sound_ratio():
 
 def test_mach_from_area_ratio_subsonic():
     fl = isentropic.IsentropicFlow(1.4)
-    A_Astar_list = [
-        np.inf,
-        2.4027,
-        1.7780,
-        1.0382,
-        1.0,
-    ]
-    expected_ratios = [
-        0.0,
-        0.25,
-        0.35,
-        0.8,
-        1.0
-    ]
-    mach_from_area_ratios = [
-        isentropic.mach_from_area_ratio(A_Astar, fl)[0]  # Subsonic
-        for A_Astar in A_Astar_list]
-    np.testing.assert_array_almost_equal(
-        mach_from_area_ratios, expected_ratios, decimal=3
-    )
+    A_Astar_list = [1e4, 2.4027, 1.7780, 1.0382, 1.0]
+    expected_ratios = [0.0, 0.25, 0.35, 0.8, 1.0]
+
+    mach_from_area_ratios = [isentropic.mach_from_area_ratio(A_Astar, fl)[0]
+                             for A_Astar in A_Astar_list]  # Subsonic
+
+    np.testing.assert_array_almost_equal(mach_from_area_ratios,
+                                         expected_ratios, decimal=3)
 
 
 def test_mach_from_area_ratio_supersonic():
+    #  https://www.engineering.com/calculators/isentropic_flow_relations.htm
     fl = isentropic.IsentropicFlow(1.4)
-    A_Astar_list = [
-        1.0,
-        1.043,
-        1.328,
-        1.902,
-        4.441
-    ]
-    expected_ratios = [
-        1.0,
-        1.24,
-        1.69,
-        2.14,
-        3.05
-    ]
-    mach_from_area_ratios = [
-        isentropic.mach_from_area_ratio(A_Astar, fl)[1]  # Supersonic
-        for A_Astar in A_Astar_list]
+    A_Astar_list = [1.0, 1.043, 1.328, 1.902, 4.441, 1e5]
+    expected_ratios = [1.0, 1.24, 1.69, 2.14, 3.05, 29.199]
 
-    np.testing.assert_array_almost_equal(
-        mach_from_area_ratios, expected_ratios, decimal=2
-    )
+    mach_from_area_ratios = [isentropic.mach_from_area_ratio(A_Astar, fl)[1]
+                             for A_Astar in A_Astar_list]  # Supersonic
+
+    np.testing.assert_array_almost_equal(mach_from_area_ratios,
+                                         expected_ratios, decimal=2)
 
 
 def test_density_ratio():


### PR DESCRIPTION
The function "mach_from_area_ratio" could not be tested for A* -> inf values as newton method (used in the calculation of supersonic solution) is not able to return "inf". Solved by testing for A* -> very large number (1e4, for example).

Also, the function failed to converge at several not so large values, so added a better initial condition that allows it to converge and do it faster.