### PR TITLE
Read the docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+sphinx:
+  fail_on_warning: true


### PR DESCRIPTION
This new file tries to solve for the non finding dependencies with `Read the docs` :rocket:  