### PR TITLE
Conversions utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = ">=3.6"
 requires = [
     "numpy",
     "matplotlib",
+    "pint",
     "scipy",    
 ]
 

--- a/src/skaero/__init__.py
+++ b/src/skaero/__init__.py
@@ -7,4 +7,10 @@ Aeronautical engineering calculations in Python
 
 """
 
+# Package version
 __version__ = "0.2.dev0"
+
+# Prellocate units module
+import pint
+
+units = pint.UnitRegistry()


### PR DESCRIPTION
This pull request solves for #45 by introducing the [Pint](https://pint.readthedocs.io/en/0.10.1/index.html) as default units manager. By simply running:

```python
from skaero import units as u

# Altitude conversion
alt = 10000.00 * u.foot
alt_meters = alt.to(u.meters)
```

This package does not introduce any other dependencies being a lightweight implementation.