### PR TITLE
Fix acceleration units

### DIFF
--- a/src/skaero/constants.py
+++ b/src/skaero/constants.py
@@ -10,4 +10,4 @@ R_earth = 6.3781366e6 * u.meters
 
 # Standard Earth's gravity acceleration value from "The International System of
 # Units by Barry N.Taylor and Ambler Thompson"
-g0 = 9.80665 * u.meters / u.seconds
+g0 = 9.80665 * u.meters / u.seconds ** 2


### PR DESCRIPTION
In last pull request #48 I introduced a small bug since the gravity acceleration was expressed in meters / second. This pull solves that issue by updating to meters / second ** 2.